### PR TITLE
Fix TinyMCE initialization for admin edit pages loaded with Turbolinks

### DIFF
--- a/app/views/alchemy/admin/pages/_tinymce_config.html.erb
+++ b/app/views/alchemy/admin/pages/_tinymce_config.html.erb
@@ -6,7 +6,7 @@
   };
 
   // Holds the default Alchemy TinyMCE configuration
-  Alchemy.Tinymce = {
+  Alchemy.Tinymce = Alchemy.Tinymce || {
     defaults: {
       plugins: '<%= Alchemy::Tinymce.plugins.join(',') %>',
       <% Alchemy::Tinymce.init.each do |k, v| %>
@@ -16,10 +16,10 @@
   };
 
 <% if Alchemy::Tinymce.custom_config_contents.any? %>
-  // Holds custom tinymce configurations
+  // Holds custom TinyMCE configurations
   Alchemy.Tinymce.customConfigs = {};
 
-  // Populate custom tinymce configurations
+  // Populate custom TinyMCE configurations
   <% Alchemy::Tinymce.custom_config_contents.each do |content| %>
   Alchemy.Tinymce.customConfigs["<%= content['element'] %>_<%= content['name'] %>"] = {
     <% content.fetch('settings', {}).fetch('tinymce', {}).each do |k, v| %>

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -112,7 +112,7 @@
 <% end %>
 
 <% content_for :javascripts do %>
-<script type="text/javascript" charset="utf-8">
+<script>
 
   $(function() {
     $('#unlock_page_form, #visit_page_form, #publish_page_form').on('submit', function(event) {

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -15,11 +15,11 @@
       // Store current locale for javascript translations.
       Alchemy.locale = '<%= ::I18n.locale %>';
     </script>
-    <%= yield :javascript_pre_init %>
-    <%= javascript_include_tag('alchemy/alchemy', "data-turbolinks-track" => true) %>
-    <%= yield :javascript_includes %>
   </head>
   <body id="alchemy" class="<%= body_class %>">
+    <%= yield :javascript_pre_init %>
+    <%= javascript_include_tag('alchemy/alchemy', "data-turbolinks-track" => true, "data-turbolinks-eval" => false) %>
+    <%= yield :javascript_includes %>
     <noscript>
       <h1><%= _t(:javascript_disabled_headline) %></h1>
       <p><%= _t(:javascript_disabled_text) %></p>


### PR DESCRIPTION
TinyMCE settings are loaded in javascript_pre_init, however this was previously in <head>. Because Turbolinks is used, scripts in the <head> are only executed on the first page load or during a page refresh. Therefore, scripts that change on each page, need to be moved into <body>. To prevent executing shared libraries on each page load, data-turbolinks-eval=false is added to the main alchemy/alchemy javascript_include_tag. Alchemy.Tinymce must also not be overwritten if it's already assigned because ALchemy.Tinymce.init is defined in alchemy.tinymce.js.coffee which is only executed on the first page load.
