### PR TITLE
Modified the CMS to support AMP pages

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -152,6 +152,10 @@ module Alchemy
           end
         end
 
+        format.amp do
+          render action: :show, layout: 'application'
+        end
+
         format.rss do
           if @page.contains_feed?
             render action: :show, layout: false, handlers: [:builder]

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -166,7 +166,7 @@ module Alchemy
       }.merge(options.delete(:locals) || {})
 
       element.store_page(@page) if part.to_sym == :view
-      render file: "alchemy/elements/_#{element.name}_#{part}", locals: options, formats: options[:render_format]
+      render partial: "alchemy/elements/#{element.name}_#{part}", locals: options, formats: options[:render_format]
     rescue ActionView::MissingTemplate => e
       warning(%(
         Element #{part} partial not found for #{element.name}.\n

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -166,7 +166,7 @@ module Alchemy
       }.merge(options.delete(:locals) || {})
 
       element.store_page(@page) if part.to_sym == :view
-      render "alchemy/elements/#{element.name}_#{part}", options
+      render file: "alchemy/elements/_#{element.name}_#{part}", locals: options, formats: options[:render_format]
     rescue ActionView::MissingTemplate => e
       warning(%(
         Element #{part} partial not found for #{element.name}.\n

--- a/app/helpers/alchemy/essences_helper.rb
+++ b/app/helpers/alchemy/essences_helper.rb
@@ -73,7 +73,7 @@ module Alchemy
         content: content,
         options: options["for_#{part}".to_sym],
         html_options: html_options
-      }
+      }, formats: options[:for_view][:render_format]
     end
 
     # Renders the +Esssence+ view partial for given +Content+.

--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -308,7 +308,7 @@ module Alchemy
       options = default_options.merge(options)
       cell = options[:from_page].cells.find_by_name(name)
       return "" if cell.blank?
-      render partial: "alchemy/cells/#{name}", locals: {cell: cell}.merge(options[:locals])
+      render partial: "alchemy/cells/#{name}", locals: {cell: cell}.merge(options[:locals]), formats: options[:render_format]
     end
 
     # Returns true or false if no elements are in the cell found by name.

--- a/lib/alchemy/routing_constraints.rb
+++ b/lib/alchemy/routing_constraints.rb
@@ -29,7 +29,7 @@ module Alchemy
     # because it could be a legacy route that needs to be redirected.
     #
     def handable_format?
-      @request.format.symbol.nil? || (@request.format.symbol == :html) || (@request.format.symbol == :rss)
+      @request.format.symbol.nil? || (@request.format.symbol == :html) || (@request.format.symbol == :rss) || (@request.format.symbol == :amp)
     end
 
     # We don't want to handle the Rails info routes.


### PR DESCRIPTION
We have generally have two separate files for each component of the CMS (from the page layout down to the essence), depending on whether the AMP version is different. The two files are differentiated by their format or extension, and we decide which of the two serve depending on the format appended to the end of page path. All AMP pages will have a page path ending in .amp. For instance, /wedding-invitations.amp or /holiday-christmas-cards.html.amp and the corresponding page layout name will be application.amp.erb (rather than application.html.erb). From there on, we explicitly pass the format down to the components on the page so that the correct version is rendered.

- Check the format (page path extension) to decide which version (AMP or HTML) of the main layout page to serve
- Used the previously supported 'render_format' variable passed in through options to decide which version (AMP or HTML) of the cell, element, etc. to render

https://app.asana.com/0/380306915042955/list